### PR TITLE
Fixed Includes?

### DIFF
--- a/oneline
+++ b/oneline
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/local/bin/perl -I .
 
 # Author: Jason Eisner, University of Pennsylvania
 
@@ -49,7 +49,7 @@
 #   5) the @ signs before some constituents (added by headify) unless it says
 #      that it's compatible with headify format.
 
-@INC=(".");
+#@INC=(".");
 require('stamp.inc');  &stamp;
 
 $numberlines = 1, shift(@ARGV) if $ARGV[0] eq "-n";  


### PR DESCRIPTION
online Line 52: @INC=(“.”); removes all -I command line include options,
making these scripts unusable from within another script with a
different working directory.  Alterations to line 1 should keep the
intent of line 51 without eliminating the -I command line options.
See:
http://stackoverflow.com/questions/2526804/how-is-perls-inc-constructed-
aka-what-are-all-the-ways-of-affecting-where-pe
